### PR TITLE
Fix for loops

### DIFF
--- a/kt-lox/src/main/kotlin/com/craftinginterpreters/lox/Expr.kt
+++ b/kt-lox/src/main/kotlin/com/craftinginterpreters/lox/Expr.kt
@@ -15,49 +15,49 @@ abstract class Expr {
 
     abstract fun <R> accept(visitor: Visitor<R>): R
 
-    data class Assign(val name: Token, val value: Expr) : Expr() {
+    class Assign(val name: Token, val value: Expr) : Expr() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitAssignExpr(this)
         }
     }
 
-    data class Binary(val left: Expr, val operator: Token, val right: Expr) : Expr() {
+    class Binary(val left: Expr, val operator: Token, val right: Expr) : Expr() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitBinaryExpr(this)
         }
     }
 
-    data class Ternary(val condition: Expr, val thenExpr: Expr, val elseExpr: Expr) : Expr() {
+    class Ternary(val condition: Expr, val thenExpr: Expr, val elseExpr: Expr) : Expr() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitTernaryExpr(this)
         }
     }
 
-    data class Grouping(val expression: Expr) : Expr() {
+    class Grouping(val expression: Expr) : Expr() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitGroupingExpr(this)
         }
     }
 
-    data class Literal(val value: Any?) : Expr() {
+    class Literal(val value: Any?) : Expr() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitLiteralExpr(this)
         }
     }
 
-    data class Logical(val left: Expr, val operator: Token, val right: Expr) : Expr() {
+    class Logical(val left: Expr, val operator: Token, val right: Expr) : Expr() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitLogicalExpr(this)
         }
     }
 
-    data class Unary(val operator: Token, val right: Expr) : Expr() {
+    class Unary(val operator: Token, val right: Expr) : Expr() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitUnaryExpr(this)
         }
     }
 
-    data class Call(val callee: Expr, val paren: Token, val arguments: List<Expr>) : Expr() {
+    class Call(val callee: Expr, val paren: Token, val arguments: List<Expr>) : Expr() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitCallExpr(this)
         }

--- a/kt-lox/src/main/kotlin/com/craftinginterpreters/lox/Stmt.kt
+++ b/kt-lox/src/main/kotlin/com/craftinginterpreters/lox/Stmt.kt
@@ -14,49 +14,49 @@ abstract class Stmt {
 
     abstract fun <R> accept(visitor: Visitor<R>): R
 
-    data class Block(val statements: List<Stmt>): Stmt() {
+    class Block(val statements: List<Stmt>) : Stmt() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitBlockStmt(this)
         }
     }
 
-    data class Expression(val expression: Expr): Stmt() {
+    class Expression(val expression: Expr) : Stmt() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitExpressionStmt(this)
         }
     }
 
-    data class Function(val name: Token, val params: List<Token>, val body: List<Stmt>): Stmt() {
+    class Function(val name: Token, val params: List<Token>, val body: List<Stmt>) : Stmt() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitFunctionStmt(this)
         }
     }
 
-    data class If(val condition: Expr, val thenBranch: Stmt, val elseBranch: Stmt?): Stmt() {
+    class If(val condition: Expr, val thenBranch: Stmt, val elseBranch: Stmt?) : Stmt() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitIfStmt(this)
         }
     }
 
-    data class Print(val expression: Expr): Stmt() {
+    class Print(val expression: Expr) : Stmt() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitPrintStmt(this)
         }
     }
 
-    data class Return(val keyword: Token, val value: Expr?): Stmt() {
+    class Return(val keyword: Token, val value: Expr?) : Stmt() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitReturnStmt(this)
         }
     }
 
-    data class Var(val name: Token, val initializer: Expr?): Stmt() {
+    class Var(val name: Token, val initializer: Expr?) : Stmt() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitVarStmt(this)
         }
     }
 
-    data class While(val condition: Expr, val body: Stmt): Stmt() {
+    class While(val condition: Expr, val body: Stmt) : Stmt() {
         override fun <R> accept(visitor: Visitor<R>): R {
             return visitor.visitWhileStmt(this)
         }

--- a/kt-lox/src/main/kotlin/com/craftinginterpreters/tool/GenerateAst.kt
+++ b/kt-lox/src/main/kotlin/com/craftinginterpreters/tool/GenerateAst.kt
@@ -84,7 +84,7 @@ class GenerateAst(outputDir: String, private val baseName: String, private val d
             "val $it"
         }
         w.println()
-        w.println("    data class ${typeDefinition.name}($params): $baseName() {")
+        w.println("    class ${typeDefinition.name}($params) : $baseName() {")
         w.println("        override fun <R> accept(visitor: Visitor<R>): R {")
         w.println("            return visitor.visit${typeDefinition.name}$baseName(this)")
         w.println("        }")


### PR DESCRIPTION
Make Expr and Stmt implementations regular classes

Data classes' equality breaks the interpreter. Two different tokens (variables) in the same line would be interpreted as the same. Even the variable token repeated in "for" syntactic sugar expansion was considered the same.

This messes with the scope resolution, where a token from different scope would override a previous one.

Fixes #1